### PR TITLE
Abstract logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
 
 ## Added
 
-* `developmentLogFormat` - uses a non-standard log format that is more verbose
-    and easier to read
+* `HTTPure.Middleware.developmentLogFormat` - uses a non-standard log format that is more verbose and easier to read
 
 # 1.0.0 - 2019-04-23
 
@@ -15,5 +14,5 @@ Initial release.
 
 ## Added
 
-* `commonLogFormat` - following the Apache common log format
-* `combinedLogFormat` - Following the Apache combined log format
+* `HTTPure.Middleware.commonLogFormat` - following the Apache common log format
+* `HTTPure.Middleware.combinedLogFormat` - Following the Apache combined log format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # Unreleased
 
+## Added
+
+* `HTTPure.Middleware.LogLifecycle` - codifies lifecycle functions for logging
+* `HTTPure.Middleware.LogTime` - codifies time data around a request
+* `HTTPure.Middleware.log` - generalizes the previous log middlewares to allow any output
+* `HTTPure.Middleware.logWithTime` - provides a simplification for logging with time
+
 # 1.1.0 - 2019-04-25
 
 ## Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-httpure-middleware",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -34,6 +34,16 @@ main = Test.Unit.Main.runTest do
         Test.Unit.Assert.equal originalResponse.headers newResponse.headers
         Test.Unit.Assert.equal originalResponse.status newResponse.status
 
+    Test.Unit.suite "log" do
+      Test.Unit.test "Doesn't alter the request" do
+        originalResponse <- router request
+        newResponse <- HTTPure.Middleware.log logLifecycle router request
+        Test.Unit.Assert.equal originalResponse.headers newResponse.headers
+        Test.Unit.Assert.equal originalResponse.status newResponse.status
+
+logLifecycle :: HTTPure.Middleware.LogLifecycle Unit
+logLifecycle = { after: mempty, before: mempty }
+
 request :: HTTPure.Request
 request =
   { body: "Testing"


### PR DESCRIPTION
We provided a few simple log middeware so people could have logging easily. This doesn't solve all cases, so we expose the underlying logging middleware to allow arbitrary output.