### PR TITLE
Add a timeout middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@
 
 * `HTTPure.Middleware.LogLifecycle` - codifies lifecycle functions for logging
 * `HTTPure.Middleware.LogTime` - codifies time data around a request
+* `HTTPure.Middleware.Middleware` - a type synonym for middlewares
 * `HTTPure.Middleware.log` - generalizes the previous log middlewares to allow any output
 * `HTTPure.Middleware.logWithTime` - provides a simplification for logging with time
+* `HTTPure.Middleware.timeout` - aborts requests if they take too long
 
 # 1.1.0 - 2019-04-25
 

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,8 @@
     "purescript-formatters": "^4.0.1",
     "purescript-arrays": "^5.2.1",
     "purescript-ansi": "^5.0.0",
-    "purescript-integers": "^4.0.0"
+    "purescript-integers": "^4.0.0",
+    "purescript-parallel": "^4.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",


### PR DESCRIPTION
This middleware will start the request, and fail it if it takes too long.
The status code is 500, because there's no more descriptive status code.
We might want to allow that to be set.