### PR TITLE
Lock down `purescript-httpure` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 * `HTTPure.Middleware.logWithTime` - provides a simplification for logging with time
 * `HTTPure.Middleware.timeout` - aborts requests if they take too long
 
+## Fixed
+
+* Lock down `purescript-httpure` version - `purescript-httpure` allows breaking changes in patch versions which conflicts with SemVer caret
+
 # 1.1.0 - 2019-04-25
 
 ## Added

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/joneshf/purescript-httpure-middleware.git"
   },
   "dependencies": {
-    "purescript-httpure": "^0.8.1",
+    "purescript-httpure": "0.8.1",
     "purescript-now": "^4.0.0",
     "purescript-prelude": "^4.1.1",
     "purescript-effect": "^2.0.1",


### PR DESCRIPTION
In SemVer, the semantics of `0.x.x` versions is unspecified. Many
projects decide their own versioning scheme. `purescript-httpure`
decided that breaking changes are fine in patch versions.

This versioning scheme doesn't work with the caret syntax of SemVer, so
we lock down to an exact version. If `purescript-httpure` decides on a
different versioning scheme, we can change this.