### PR TITLE
Bump `purescript-httpure` version to `0.8.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+## Changed
+
+* Update `purescript-httpure` to `0.8.2`
+
 # 1.2.1 - 2019-12-08
 
 ## Fixed

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "purescript-effect": ">= 2.0.1 < 3.0.0",
     "purescript-formatters": ">= 4.0.1 < 5.0.0",
     "purescript-foreign-object": ">= 1.0.0 < 2.0.0",
-    "purescript-httpure": "0.8.1",
+    "purescript-httpure": "0.8.2",
     "purescript-integers": ">= 4.0.0 < 5.0.0",
     "purescript-maybe": ">= 4.0.1 < 5.0.0",
     "purescript-now": ">= 4.0.0 < 5.0.0",

--- a/src/HTTPure/Middleware.purs
+++ b/src/HTTPure/Middleware.purs
@@ -17,11 +17,13 @@ import Ansi.Output as Ansi.Output
 import Control.Parallel as Control.Parallel
 import Data.Array as Data.Array
 import Data.DateTime as Data.DateTime
+import Data.Foldable as Data.Foldable
 import Data.FoldableWithIndex as Data.FoldableWithIndex
 import Data.Formatter.DateTime as Data.Formatter.DateTime
 import Data.Int as Data.Int
 import Data.Maybe as Data.Maybe
 import Data.String as Data.String
+import Data.String.CaseInsensitive as Data.String.CaseInsensitive
 import Data.Time.Duration as Data.Time.Duration
 import Effect.Aff as Effect.Aff
 import Effect.Class as Effect.Class
@@ -125,7 +127,7 @@ developmentLogFormat' logTime request response =
         ( method
           <> object "Query" request.query
           <> body
-          <> object "Headers" headers
+          <> fromHeaders "Headers" headers
           <> duration
           <> status response.status
         )
@@ -136,6 +138,12 @@ developmentLogFormat' logTime request response =
     | otherwise = []
   duration =
     ["  " <> white "Duration" <> ": " <> renderDuration logTime.duration]
+  fromHeaders name obj
+    | not Data.Foldable.null obj =
+      [ "  " <> white name <> ":"
+      ] <> flip Data.FoldableWithIndex.foldMapWithIndex obj \(Data.String.CaseInsensitive.CaseInsensitiveString key) val ->
+        ["    " <> white key <> ": " <> val]
+    | otherwise = []
   method =
     [colorMethod request.method <> " /" <> Data.String.joinWith "/" request.path]
   object name obj

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -8,6 +8,7 @@ import Effect.Aff as Effect.Aff
 import Foreign.Object as Foreign.Object
 import HTTPure as HTTPure
 import HTTPure.Middleware as HTTPure.Middleware
+import HTTPure.Version as HTTPure.Version
 import Test.Unit as Test.Unit
 import Test.Unit.Assert as Test.Unit.Assert
 import Test.Unit.Main as Test.Unit.Main
@@ -61,6 +62,7 @@ request :: HTTPure.Request
 request =
   { body: "Testing"
   , headers: HTTPure.header "Content-Type" "text/plain"
+  , httpVersion: HTTPure.Version.HTTP1_1
   , method: HTTPure.Patch
   , path: ["foo", "bar", "baz.html"]
   , query: Foreign.Object.fromHomogeneous { qux: "gar" }


### PR DESCRIPTION
This version had some breaking changes, so we'll have to bump the major
version when we make a release.