### PR TITLE
Bump `purescript-httpure` to `0.8.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+## Changed
+
+* Bump `purescript-httpure` to `0.8.3` - transitive dependencies require a major version bump
+
 # 2.1.0 - 2019-12-08
 
 ## Changed

--- a/bower.json
+++ b/bower.json
@@ -21,18 +21,18 @@
     "purescript-console": ">= 4.2.0 < 5.0.0",
     "purescript-effect": ">= 2.0.1 < 3.0.0",
     "purescript-formatters": ">= 4.0.1 < 5.0.0",
-    "purescript-foreign-object": ">= 1.0.0 < 2.0.0",
-    "purescript-httpure": "0.8.2",
+    "purescript-foreign-object": ">= 1.0.0 < 3.0.0",
+    "purescript-httpure": "0.8.3",
     "purescript-integers": ">= 4.0.0 < 5.0.0",
     "purescript-maybe": ">= 4.0.1 < 5.0.0",
     "purescript-now": ">= 4.0.0 < 5.0.0",
-    "purescript-options": ">= 4.0.0 < 5.0.0",
+    "purescript-options": ">= 4.0.0 < 6.0.0",
     "purescript-parallel": ">= 4.0.0 < 5.0.0",
     "purescript-prelude": ">= 4.1.1 < 5.0.0",
     "purescript-strings": ">= 4.0.1 < 5.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": ">= 4.0.0 < 5.0.0",
-    "purescript-test-unit": ">= 14.0.0 < 15.0.0"
+    "purescript-test-unit": ">= 14.0.0 < 16.0.0"
   }
 }


### PR DESCRIPTION
The transitive dependencies changed in a way that this change can break
consumers of `purescript-httpure-middleware`. To mitigate the fallout,
we will have to release this as a major version bump.