### PR TITLE
Bump `purescript-httpure` to `0.10.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+## Changed
+
+* Bump `purescript-httpure` to `0.10.0` - non-breaking changes should allow this to be a patch version bump
+
 # 3.0.1 - 2019-12-08
 
 ## Changed

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "purescript-effect": ">= 2.0.1 < 3.0.0",
     "purescript-formatters": ">= 4.0.1 < 5.0.0",
     "purescript-foreign-object": ">= 1.0.0 < 3.0.0",
-    "purescript-httpure": "0.8.3 || 0.9.0",
+    "purescript-httpure": "0.8.3 || 0.9.0 || 0.10.0",
     "purescript-integers": ">= 4.0.0 < 5.0.0",
     "purescript-maybe": ">= 4.0.1 < 5.0.0",
     "purescript-now": ">= 4.0.0 < 5.0.0",


### PR DESCRIPTION
Even though a ton of type signatures changed, the change wasn't a
breaking change. Though `purescript-httpure` decided to make a minor
release, we don't have to force that onto our consumers.