### PR TITLE
Use a tag for `purescript-httpure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+## Changed
+
+* Bump `purescript-httpure` to `0.12.0` - non-breaking changes should allow this to be a patch version bump
+
 # 4.0.0 - 2021-03-20
 ## Changed
 

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "purescript-effect": ">= 3.0.0 < 4.0.0",
     "purescript-formatters": ">= 5.0.0 < 6.0.0",
     "purescript-foreign-object": ">= 3.0.0 < 4.0.0",
-    "purescript-httpure": "036318aba04b0a2a152895a26d4fe909208f194c",
+    "purescript-httpure": "0.12.0",
     "purescript-integers": ">= 5.0.0 < 6.0.0",
     "purescript-maybe": ">= 5.0.0 < 6.0.0",
     "purescript-now": ">= 5.0.0 < 6.0.0",


### PR DESCRIPTION
It's a bit easier to work with a tag than a commit SHA.

As in the past, we do not specify ranges for `purescript-httpure`. The
API has been known to break in the past, so we want to explicitly opt-in
to versions of `purescript-httpure`.